### PR TITLE
Use 'SyncRequirePlugin' attribute make reference with other plugin

### DIFF
--- a/RealTimePPDisplayer.cs
+++ b/RealTimePPDisplayer.cs
@@ -6,6 +6,7 @@ using System.Linq;
 
 namespace RealTimePPDisplayer
 {
+    [SyncRequirePlugin(typeof(OsuRTDataProviderPlugin))]
     public class RealTimePPDisplayerPlugin : Plugin
     {
         public const string PLUGIN_NAME = "RealTimePPDisplayer";
@@ -17,42 +18,28 @@ namespace RealTimePPDisplayer
 
         public override void OnEnable()
         {
-            base.OnEnable();
+            I18n.Instance.ApplyLanguage(new DefaultLanguage());
+            Setting.PluginInstance = this;
+
+            m_memory_reader = getHoster().EnumPluings().Where(p => p.Name == "OsuRTDataProvider").FirstOrDefault() as OsuRTDataProviderPlugin;
+
+            if (m_memory_reader.TourneyListenerManagers == null)
+            {
+                m_osu_pp_displayers[0] = new PPControl(m_memory_reader.ListenerManager, null);
+            }
+            else
+            {
+                for (int i = 0; i < m_memory_reader.TourneyListenerManagersCount; i++)
+                {
+                    m_osu_pp_displayers[i] = new PPControl(m_memory_reader.TourneyListenerManagers[i], i);
+                }
+            }
             Sync.Tools.IO.CurrentIO.WriteColor(PLUGIN_NAME + " By " + PLUGIN_AUTHOR, ConsoleColor.DarkCyan);
         }
 
         public RealTimePPDisplayerPlugin() : base(PLUGIN_NAME, PLUGIN_AUTHOR)
         {
-            I18n.Instance.ApplyLanguage(new DefaultLanguage());
-            base.EventBus.BindEvent<PluginEvents.LoadCompleteEvent>(InitPlugin);
         }
-
-        private bool _is_inited = false;
-        private object _mtx = new object();
-
-        private void InitPlugin(PluginEvents.LoadCompleteEvent e)
-        {
-            lock (_mtx)
-            {
-                if (_is_inited) return;
-
-                Setting.PluginInstance = this;
-
-                m_memory_reader = e.Host.EnumPluings().Where(p => p.Name == "OsuRTDataProvider").FirstOrDefault() as OsuRTDataProviderPlugin;
-
-                if (m_memory_reader.TourneyListenerManagers == null)
-                {
-                    m_osu_pp_displayers[0] = new PPControl(m_memory_reader.ListenerManager, null);
-                }
-                else
-                {
-                    for (int i = 0; i < m_memory_reader.TourneyListenerManagersCount; i++)
-                    {
-                        m_osu_pp_displayers[i] = new PPControl(m_memory_reader.TourneyListenerManagers[i], i);
-                    }
-                }
-                _is_inited = true;
-            }
-        }
+        
     }
 }


### PR DESCRIPTION
[SyncRequirePlugin] attribute can change plugin load order with reference properties. Use this to instead 'Plugin LoadComplete' Event and locks